### PR TITLE
Fix TMP permissions to avoid UPLOAD_ERR_NO_TMP_DIR.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM php:7.1-apache
 
 ADD root/ /
+# Fix the original permissions of /tmp, the PHP default upload tmp dir.
+RUN chmod 777 /tmp && chmod +t /tmp
+# Setup the required extensions.
 RUN /tmp/setup/php-extensions.sh
 RUN /tmp/setup/oci8-extension.sh
 


### PR DESCRIPTION
Related issues: danpoltawski/docker-moodle#9.